### PR TITLE
Add counterpart manager

### DIFF
--- a/contracts/adapters/GlacisAbstractAdapter.sol
+++ b/contracts/adapters/GlacisAbstractAdapter.sol
@@ -19,7 +19,10 @@ error GlacisAbstractAdapter__NoRemoteAdapterForChainId(uint256 chainId); //0xb29
 /// @title Glacis Abstract Adapter for all GMPs
 /// @notice All adapters inheriting from this contract will be able to receive GlacisRouter requests through _sendMessage
 /// function
-abstract contract GlacisAbstractAdapter is GlacisRemoteCounterpartManager, IGlacisAdapter {
+abstract contract GlacisAbstractAdapter is
+    GlacisRemoteCounterpartManager,
+    IGlacisAdapter
+{
     IGlacisRouter public immutable GLACIS_ROUTER;
 
     constructor(IGlacisRouter _glacisRouter, address owner_) {

--- a/contracts/adapters/GlacisAbstractAdapter.sol
+++ b/contracts/adapters/GlacisAbstractAdapter.sol
@@ -4,14 +4,13 @@ pragma solidity 0.8.18;
 
 import {IGlacisRouter} from "../interfaces/IGlacisRouter.sol";
 import {IGlacisAdapter} from "../interfaces/IGlacisAdapter.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {GlacisRemoteCounterpartManager} from "../managers/GlacisRemoteCounterpartManager.sol";
 
 error GlacisAbstractAdapter__OnlyGlacisRouterAllowed();
 error GlacisAbstractAdapter__OnlyAdapterAllowed();
 error GlacisAbstractAdapter__DestinationChainIdNotValid();
 error GlacisAbstractAdapter__InvalidAdapterAddress();
 error GlacisAbstractAdapter__InvalidChainId();
-error GlacisAbstractAdapter__ChainCannotBeZero();
 error GlacisAbstractAdapter__NoAdapterConfiguredForChain();
 error GlacisAbstractAdapter__SourceChainNotRegistered();
 error GlacisAbstractAdapter__IDArraysMustBeSameLength();
@@ -20,10 +19,8 @@ error GlacisAbstractAdapter__NoRemoteAdapterForChainId(uint256 chainId); //0xb29
 /// @title Glacis Abstract Adapter for all GMPs
 /// @notice All adapters inheriting from this contract will be able to receive GlacisRouter requests through _sendMessage
 /// function
-abstract contract GlacisAbstractAdapter is IGlacisAdapter, Ownable {
+abstract contract GlacisAbstractAdapter is GlacisRemoteCounterpartManager, IGlacisAdapter {
     IGlacisRouter public immutable GLACIS_ROUTER;
-
-    mapping(uint256 => address) public remoteAdapters;
 
     constructor(IGlacisRouter _glacisRouter, address owner_) {
         transferOwnership(owner_);
@@ -59,33 +56,13 @@ abstract contract GlacisAbstractAdapter is IGlacisAdapter, Ownable {
         _;
     }
 
-    /// @notice Adds a remote adapter on a destination chain where this adapter can route messages
-    /// @param chainId The chainId to add the remote adapter
-    /// @param adapter The address of the adapter on remote chain
-    function _addRemoteAdapter(
-        uint256 chainId,
-        address adapter
-    ) internal onlyOwner {
-        if (address(adapter) == address(0))
-            revert GlacisAbstractAdapter__InvalidAdapterAddress();
-        if (chainId == 0) revert GlacisAbstractAdapter__ChainCannotBeZero();
-        remoteAdapters[chainId] = adapter;
-    }
-
-    /// @notice Removes an authorized adapter on remote chain that this adapter accepts messages from
-    /// @param chainId The chainId to remove the remote adapter
-    function _removeRemoteAdapter(uint256 chainId) internal onlyOwner {
-        if (chainId == 0) revert GlacisAbstractAdapter__ChainCannotBeZero();
-        delete remoteAdapters[chainId];
-    }
-
     /// @notice Verifies that the source address of the request is an authorized adapter
     /// @param sourceAddress Source address
     modifier onlyAuthorizedAdapter(uint256 chainId, address sourceAddress) {
         if (
             chainId == 0 ||
-            remoteAdapters[chainId] == address(0) ||
-            sourceAddress != remoteAdapters[chainId]
+            remoteCounterpart[chainId] == address(0) ||
+            sourceAddress != remoteCounterpart[chainId]
         ) {
             revert GlacisAbstractAdapter__OnlyAdapterAllowed();
         }

--- a/contracts/adapters/GlacisAxelarAdapter.sol
+++ b/contracts/adapters/GlacisAxelarAdapter.sol
@@ -80,20 +80,6 @@ contract GlacisAxelarAdapter is GlacisAbstractAdapter, AxelarExecutable {
         return bytes(glacisChainIdToAdapterChainId[chainId]).length > 0;
     }
 
-    /// @notice Adds a remote adapter on a destination chain where this adapter can route messages
-    /// @param chainId The chainId to add the remote adapter
-    /// @param adapter The address of the adapter on remote chain
-    function addRemoteAdapter(uint256 chainId, address adapter) external {
-        if (!chainIsAvailable(chainId))
-            revert GlacisAbstractAdapter__DestinationChainIdNotValid();
-        _addRemoteAdapter(chainId, adapter);
-    }
-
-    /// @notice Removes an authorized adapter on remote chain that this adapter accepts messages from
-    /// @param chainId The chainId to remove the remote adapter
-    function removeRemoteAdapter(uint256 chainId) external {
-        _removeRemoteAdapter(chainId);
-    }
 
     /// @notice Dispatch payload to specified Glacis chain ID and address through Axelar GMP
     /// @param toChainId Destination chain (Glacis ID)
@@ -107,9 +93,9 @@ contract GlacisAxelarAdapter is GlacisAbstractAdapter, AxelarExecutable {
         string memory destinationChain = glacisChainIdToAdapterChainId[
             toChainId
         ];
-        if (remoteAdapters[toChainId] == address(0))
+        if (remoteCounterpart[toChainId] == address(0))
             revert GlacisAbstractAdapter__NoRemoteAdapterForChainId(toChainId);
-        string memory destinationAddress = remoteAdapters[toChainId]
+        string memory destinationAddress = remoteCounterpart[toChainId]
             .toHexString();
         if (bytes(destinationChain).length == 0)
             revert IGlacisAdapter__ChainIsNotAvailable(toChainId);

--- a/contracts/adapters/GlacisAxelarAdapter.sol
+++ b/contracts/adapters/GlacisAxelarAdapter.sol
@@ -80,7 +80,6 @@ contract GlacisAxelarAdapter is GlacisAbstractAdapter, AxelarExecutable {
         return bytes(glacisChainIdToAdapterChainId[chainId]).length > 0;
     }
 
-
     /// @notice Dispatch payload to specified Glacis chain ID and address through Axelar GMP
     /// @param toChainId Destination chain (Glacis ID)
     /// @param refundAddress The address to refund native asset surplus

--- a/contracts/adapters/GlacisCCIPAdapter.sol
+++ b/contracts/adapters/GlacisCCIPAdapter.sol
@@ -103,7 +103,7 @@ contract GlacisCCIPAdapter is GlacisAbstractAdapter, CCIPReceiver {
 
         // Create an EVM2AnyMessage struct in memory with necessary information for sending a cross-chain message
         Client.EVM2AnyMessage memory evm2AnyMessage = Client.EVM2AnyMessage({
-            receiver: abi.encode(address(this)), // ABI-encoded receiver address
+            receiver: abi.encode(remoteCounterpart[toChainId]), // ABI-encoded receiver address
             data: payload,
             tokenAmounts: new Client.EVMTokenAmount[](0), // Empty array aas no tokens are transferred
             // NOTE: extraArgs is subject to changes by CCIP in the future.
@@ -213,14 +213,5 @@ contract GlacisCCIPAdapter is GlacisAbstractAdapter, CCIPReceiver {
 
         // Calculates x = (y-b) / m, but increased m by 0.5% to overestimate value needed
         return (value - b) / (m + (m / 200));
-    }
-
-    /// @notice Adds a remote adapter on a destination chain where this adapter can route messages
-    /// @param chainId The chainId to add the remote adapter
-    /// @param adapter The address of the adapter on remote chain
-    function addRemoteAdapter(uint256 chainId, address adapter) external {
-        if (!chainIsAvailable(chainId))
-            revert GlacisAbstractAdapter__DestinationChainIdNotValid();
-        _addRemoteAdapter(chainId, adapter);
     }
 }

--- a/contracts/adapters/GlacisHyperlaneAdapter.sol
+++ b/contracts/adapters/GlacisHyperlaneAdapter.sol
@@ -102,7 +102,8 @@ contract GlacisHyperlaneAdapter is GlacisAbstractAdapter {
         );
 
         // Ensure that we have enough of the required fee (will revert if not this value)
-        bytes32 destinationAddress = remoteCounterpart[toChainId].addressToBytes32();
+        bytes32 destinationAddress = remoteCounterpart[toChainId]
+            .addressToBytes32();
         uint256 nativePriceQuote = MAIL_BOX.quoteDispatch(
             destinationDomain,
             destinationAddress,
@@ -160,6 +161,4 @@ contract GlacisHyperlaneAdapter is GlacisAbstractAdapter {
 
         GLACIS_ROUTER.receiveMessage(glacisChainId, _message);
     }
-
-
 }

--- a/contracts/adapters/GlacisHyperlaneAdapter.sol
+++ b/contracts/adapters/GlacisHyperlaneAdapter.sol
@@ -102,7 +102,7 @@ contract GlacisHyperlaneAdapter is GlacisAbstractAdapter {
         );
 
         // Ensure that we have enough of the required fee (will revert if not this value)
-        bytes32 destinationAddress = address(this).addressToBytes32();
+        bytes32 destinationAddress = remoteCounterpart[toChainId].addressToBytes32();
         uint256 nativePriceQuote = MAIL_BOX.quoteDispatch(
             destinationDomain,
             destinationAddress,
@@ -161,12 +161,5 @@ contract GlacisHyperlaneAdapter is GlacisAbstractAdapter {
         GLACIS_ROUTER.receiveMessage(glacisChainId, _message);
     }
 
-    /// @notice Adds a remote adapter on a destination chain where this adapter can route messages
-    /// @param chainId The chainId to add the remote adapter
-    /// @param adapter The address of the adapter on remote chain
-    function addRemoteAdapter(uint256 chainId, address adapter) external {
-        if (!chainIsAvailable(chainId))
-            revert GlacisAbstractAdapter__DestinationChainIdNotValid();
-        _addRemoteAdapter(chainId, adapter);
-    }
+
 }

--- a/contracts/adapters/LayerZero/GlacisLayerZeroAdapter.sol
+++ b/contracts/adapters/LayerZero/GlacisLayerZeroAdapter.sol
@@ -71,20 +71,6 @@ contract GlacisLayerZeroAdapter is
         return glacisChainIdToAdapterChainId[chainId] != 0;
     }
 
-    /// @notice Adds a remote adapter on a destination chain where this adapter can route messages
-    /// @param chainId The chainId to add the remote adapter
-    /// @param adapter The address of the adapter on remote chain
-    function addRemoteAdapter(uint256 chainId, address adapter) external {
-        if (!chainIsAvailable(chainId))
-            revert GlacisAbstractAdapter__DestinationChainIdNotValid();
-        _addRemoteAdapter(chainId, adapter);
-    }
-
-    /// @notice Removes an authorized adapter on remote chain that this adapter accepts messages from
-    /// @param chainId The chainId to remove the remote adapter
-    function removeRemoteAdapter(uint256 chainId) external {
-        _removeRemoteAdapter(chainId);
-    }
 
     /// @notice Dispatch payload to specified Glacis chain ID and address through LayerZero GMP
     /// @param toChainId Destination chain (Glacis ID)
@@ -100,7 +86,7 @@ contract GlacisLayerZeroAdapter is
             revert IGlacisAdapter__ChainIsNotAvailable(toChainId);
         _lzSend({
             _dstChainId: glacisChainIdToAdapterChainId[toChainId],
-            _dstChainAddress: remoteAdapters[toChainId],
+            _dstChainAddress: remoteCounterpart[toChainId],
             _payload: payload,
             _refundAddress: payable(refundAddress),
             _zroPaymentAddress: address(0x0),

--- a/contracts/adapters/LayerZero/GlacisLayerZeroAdapter.sol
+++ b/contracts/adapters/LayerZero/GlacisLayerZeroAdapter.sol
@@ -71,7 +71,6 @@ contract GlacisLayerZeroAdapter is
         return glacisChainIdToAdapterChainId[chainId] != 0;
     }
 
-
     /// @notice Dispatch payload to specified Glacis chain ID and address through LayerZero GMP
     /// @param toChainId Destination chain (Glacis ID)
     /// @param refundAddress The address to refund native asset surplus

--- a/contracts/adapters/Wormhole/GlacisWormholeAdapter.sol
+++ b/contracts/adapters/Wormhole/GlacisWormholeAdapter.sol
@@ -152,6 +152,4 @@ contract GlacisWormholeAdapter is IWormholeReceiver, GlacisAbstractAdapter {
     function chainIsAvailable(uint256 chainId) public view returns (bool) {
         return glacisChainIdToAdapterChainId[chainId] != 0;
     }
-
-
 }

--- a/contracts/adapters/Wormhole/GlacisWormholeAdapter.sol
+++ b/contracts/adapters/Wormhole/GlacisWormholeAdapter.sol
@@ -23,9 +23,11 @@ contract GlacisWormholeAdapter is IWormholeReceiver, GlacisAbstractAdapter {
     mapping(uint256 => uint16) public glacisChainIdToAdapterChainId;
     mapping(uint16 => uint256) public adapterChainIdToGlacisChainId;
 
+    // TODO: figure out a better solution for the gas limit
     uint256 internal constant GAS_LIMIT = 900000;
     uint16 internal immutable WORMHOLE_CHAIN_ID;
 
+    // TODO: Look into transfers with token to see if this too can be abstracted.
     uint256 internal constant RECEIVER_VALUE = 0;
 
     constructor(
@@ -59,7 +61,7 @@ contract GlacisWormholeAdapter is IWormholeReceiver, GlacisAbstractAdapter {
 
         WORMHOLE_RELAYER.sendPayloadToEvm{value: nativePriceQuote}(
             destinationChainId,
-            address(this),
+            remoteCounterpart[toChainId],
             payload,
             RECEIVER_VALUE,
             GAS_LIMIT,
@@ -83,7 +85,7 @@ contract GlacisWormholeAdapter is IWormholeReceiver, GlacisAbstractAdapter {
     /// @param deliveryHash Wormhole delivery hash
     function receiveWormholeMessages(
         bytes memory payload,
-        bytes[] memory,
+        bytes[] memory, // TODO: figure out the use of the additional VAAs
         bytes32 sourceAddress,
         uint16 sourceChain,
         bytes32 deliveryHash
@@ -151,18 +153,5 @@ contract GlacisWormholeAdapter is IWormholeReceiver, GlacisAbstractAdapter {
         return glacisChainIdToAdapterChainId[chainId] != 0;
     }
 
-    /// @notice Adds a remote adapter on a destination chain where this adapter can route messages
-    /// @param chainId The chainId to add the remote adapter
-    /// @param adapter The address of the adapter on remote chain
-    function addRemoteAdapter(uint256 chainId, address adapter) external {
-        if (!chainIsAvailable(chainId))
-            revert GlacisAbstractAdapter__DestinationChainIdNotValid();
-        _addRemoteAdapter(chainId, adapter);
-    }
 
-    /// @notice Removes an authorized adapter on remote chain that this adapter accepts messages from
-    /// @param chainId The chainId to remove the remote adapter
-    function removeRemoteAdapter(uint256 chainId) external {
-        _removeRemoteAdapter(chainId);
-    }
 }

--- a/contracts/managers/GlacisRemoteCounterpartManager.sol
+++ b/contracts/managers/GlacisRemoteCounterpartManager.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity 0.8.18;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+error GlacisRemoteCounterpartManager__RemoteMediatorCannotHaveChainIdZero();
+error GlacisRemoteCounterpartManager__MediatorsAndChainIDsMustHaveSameLength();
+
+contract GlacisRemoteCounterpartManager is Ownable {
+
+    mapping(uint256 => address) public remoteCounterpart;
+
+    /// @notice Adds an authorized glacis counterpart component in a remote chain that interacts with this component
+    /// @param chainIds An array with chains of the glacis remote components
+    /// @param glacisComponents An array of addresses of the glacis components on remote chains
+    function addRemoteCounterpart(
+        uint256[] calldata chainIds,
+        address[] calldata glacisComponents
+    ) external onlyOwner {
+        if (chainIds.length != glacisComponents.length)
+            revert GlacisRemoteCounterpartManager__MediatorsAndChainIDsMustHaveSameLength();
+
+        for (uint256 i; i < chainIds.length; ++i) {
+            if (chainIds[i] == 0)
+                revert GlacisRemoteCounterpartManager__RemoteMediatorCannotHaveChainIdZero();
+            remoteCounterpart[chainIds[i]] = glacisComponents[i];
+        }
+    }
+
+    /// @notice Removes an authorized glacis counterpart component on remote chain that this components interacts with
+    /// @param chainId The chainId to remove the remote component
+    function removeRemoteCounterpart(uint256 chainId) external onlyOwner {
+        if (chainId == 0)
+            revert GlacisRemoteCounterpartManager__RemoteMediatorCannotHaveChainIdZero();
+        delete remoteCounterpart[chainId];
+    }
+}

--- a/contracts/managers/GlacisRemoteCounterpartManager.sol
+++ b/contracts/managers/GlacisRemoteCounterpartManager.sol
@@ -8,13 +8,12 @@ error GlacisRemoteCounterpartManager__RemoteMediatorCannotHaveChainIdZero();
 error GlacisRemoteCounterpartManager__MediatorsAndChainIDsMustHaveSameLength();
 
 contract GlacisRemoteCounterpartManager is Ownable {
-
     mapping(uint256 => address) public remoteCounterpart;
 
     /// @notice Adds an authorized glacis counterpart component in a remote chain that interacts with this component
     /// @param chainIds An array with chains of the glacis remote components
     /// @param glacisComponents An array of addresses of the glacis components on remote chains
-    function addRemoteCounterpart(
+    function addRemoteCounterparts(
         uint256[] calldata chainIds,
         address[] calldata glacisComponents
     ) external onlyOwner {

--- a/contracts/mediators/GlacisTokenMediator.sol
+++ b/contracts/mediators/GlacisTokenMediator.sol
@@ -10,13 +10,16 @@ import {IXERC20, IXERC20GlacisExtension} from "../interfaces/IXERC20.sol";
 import {GlacisCommons} from "../commons/GlacisCommons.sol";
 import {GlacisRemoteCounterpartManager} from "../managers/GlacisRemoteCounterpartManager.sol";
 import {GlacisClient__CanOnlyBeCalledByRouter} from "../client/GlacisClient.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 error GlacisTokenMediator__OnlyTokenMediatorAllowed();
 error GlacisTokenMediator__IncorrectTokenVariant(address, uint256);
 error GlacisTokenMediator__DestinationChainUnavailable();
 
-contract GlacisTokenMediator is IGlacisTokenMediator, GlacisRemoteCounterpartManager,  IGlacisClient {
+contract GlacisTokenMediator is
+    IGlacisTokenMediator,
+    GlacisRemoteCounterpartManager,
+    IGlacisClient
+{
     constructor(
         address glacisRouter_,
         uint256 quorum,
@@ -28,7 +31,6 @@ contract GlacisTokenMediator is IGlacisTokenMediator, GlacisRemoteCounterpartMan
     }
 
     address public immutable GLACIS_ROUTER;
-
 
     /// @notice Routes the payload to the specific address on destination chain through GlacisRouter using GMPs
     /// specified in gmps array
@@ -313,6 +315,4 @@ contract GlacisTokenMediator is IGlacisTokenMediator, GlacisRemoteCounterpartMan
             (address, address, address, address, uint256, bytes)
         );
     }
-
-
 }

--- a/test/LocalTestSetup.sol
+++ b/test/LocalTestSetup.sol
@@ -133,9 +133,11 @@ contract LocalTestSetup is Test {
         glacisIDs[0] = block.chainid;
         string[] memory axelarLabels = new string[](1);
         axelarLabels[0] = "Anvil";
+        
         adapter.setGlacisChainIds(glacisIDs, axelarLabels);
-
-        adapter.addRemoteAdapter(block.chainid, address(adapter));
+        address[] memory adapterCounterparts = new address[](1);
+        adapterCounterparts[0] = address(adapter);
+        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
 
         return adapter;
     }
@@ -158,7 +160,9 @@ contract LocalTestSetup is Test {
         adapter.setGlacisChainIds(glacisIDs, lzIDs);
 
         router.registerAdapter(LAYERZERO_GMP_ID, address(adapter));
-        adapter.addRemoteAdapter(block.chainid, address(adapter));
+        address[] memory adapterCounterparts = new address[](1);
+        adapterCounterparts[0] = address(adapter);
+        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
 
         return adapter;
     }
@@ -183,7 +187,9 @@ contract LocalTestSetup is Test {
         adapter.setGlacisChainIds(glacisIDs, wormholeIDs);
 
         router.registerAdapter(WORMHOLE_GMP_ID, address(adapter));
-        adapter.addRemoteAdapter(block.chainid, address(adapter));
+        address[] memory adapterCounterparts = new address[](1);
+        adapterCounterparts[0] = address(adapter);
+        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
 
         wormholeRelayer.setGlacisAdapter(address(adapter));
 
@@ -208,7 +214,9 @@ contract LocalTestSetup is Test {
 
         adapter.setAdapterChains(glacisIDs, chainSelectors);
         router.registerAdapter(CCIP_GMP_ID, address(adapter));
-        adapter.addRemoteAdapter(block.chainid, address(adapter));
+        address[] memory adapterCounterparts = new address[](1);
+        adapterCounterparts[0] = address(adapter);
+        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
 
         return adapter;
     }
@@ -232,7 +240,9 @@ contract LocalTestSetup is Test {
         adapter.setGlacisChainIds(glacisIDs, hyperlaneDomains);
 
         router.registerAdapter(HYPERLANE_GMP_ID, address(adapter));
-        adapter.addRemoteAdapter(block.chainid, address(adapter));
+        address[] memory adapterCounterparts = new address[](1);
+        adapterCounterparts[0] = address(adapter);
+        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
 
         return adapter;
     }
@@ -361,7 +371,7 @@ contract LocalTestSetup is Test {
         chainIdArr[0] = block.chainid;
         address[] memory mediatorArr = new address[](1);
         mediatorArr[0] = address(glacisTokenMediator);
-        glacisTokenMediator.addRemoteMediators(chainIdArr, mediatorArr);
+        glacisTokenMediator.addRemoteCounterpart(chainIdArr, mediatorArr);
     }
 
     // endregion

--- a/test/LocalTestSetup.sol
+++ b/test/LocalTestSetup.sol
@@ -133,11 +133,11 @@ contract LocalTestSetup is Test {
         glacisIDs[0] = block.chainid;
         string[] memory axelarLabels = new string[](1);
         axelarLabels[0] = "Anvil";
-        
+
         adapter.setGlacisChainIds(glacisIDs, axelarLabels);
         address[] memory adapterCounterparts = new address[](1);
         adapterCounterparts[0] = address(adapter);
-        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
+        adapter.addRemoteCounterparts(glacisIDs, adapterCounterparts);
 
         return adapter;
     }
@@ -162,7 +162,7 @@ contract LocalTestSetup is Test {
         router.registerAdapter(LAYERZERO_GMP_ID, address(adapter));
         address[] memory adapterCounterparts = new address[](1);
         adapterCounterparts[0] = address(adapter);
-        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
+        adapter.addRemoteCounterparts(glacisIDs, adapterCounterparts);
 
         return adapter;
     }
@@ -189,7 +189,7 @@ contract LocalTestSetup is Test {
         router.registerAdapter(WORMHOLE_GMP_ID, address(adapter));
         address[] memory adapterCounterparts = new address[](1);
         adapterCounterparts[0] = address(adapter);
-        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
+        adapter.addRemoteCounterparts(glacisIDs, adapterCounterparts);
 
         wormholeRelayer.setGlacisAdapter(address(adapter));
 
@@ -216,7 +216,7 @@ contract LocalTestSetup is Test {
         router.registerAdapter(CCIP_GMP_ID, address(adapter));
         address[] memory adapterCounterparts = new address[](1);
         adapterCounterparts[0] = address(adapter);
-        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
+        adapter.addRemoteCounterparts(glacisIDs, adapterCounterparts);
 
         return adapter;
     }
@@ -242,7 +242,7 @@ contract LocalTestSetup is Test {
         router.registerAdapter(HYPERLANE_GMP_ID, address(adapter));
         address[] memory adapterCounterparts = new address[](1);
         adapterCounterparts[0] = address(adapter);
-        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
+        adapter.addRemoteCounterparts(glacisIDs, adapterCounterparts);
 
         return adapter;
     }
@@ -371,7 +371,7 @@ contract LocalTestSetup is Test {
         chainIdArr[0] = block.chainid;
         address[] memory mediatorArr = new address[](1);
         mediatorArr[0] = address(glacisTokenMediator);
-        glacisTokenMediator.addRemoteCounterpart(chainIdArr, mediatorArr);
+        glacisTokenMediator.addRemoteCounterparts(chainIdArr, mediatorArr);
     }
 
     // endregion

--- a/test/client/retryManager.t.sol
+++ b/test/client/retryManager.t.sol
@@ -51,7 +51,7 @@ contract RetryTests is LocalTestSetup, IGlacisRouterEvents {
         adapter.setGlacisChainIds(glacisIDs, axelarLabels);
         address[] memory adapterCounterparts = new address[](1);
         adapterCounterparts[0] = address(adapter);
-        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
+        adapter.addRemoteCounterparts(glacisIDs, adapterCounterparts);
         assertEq(
             glacisRouter.glacisGMPIdToAdapter(AXELAR_GMP_ID),
             address(adapter)

--- a/test/client/retryManager.t.sol
+++ b/test/client/retryManager.t.sol
@@ -49,8 +49,9 @@ contract RetryTests is LocalTestSetup, IGlacisRouterEvents {
         string[] memory axelarLabels = new string[](1);
         axelarLabels[0] = "Anvil";
         adapter.setGlacisChainIds(glacisIDs, axelarLabels);
-        adapter.addRemoteAdapter(block.chainid, address(adapter));
-
+        address[] memory adapterCounterparts = new address[](1);
+        adapterCounterparts[0] = address(adapter);
+        adapter.addRemoteCounterpart(glacisIDs, adapterCounterparts);
         assertEq(
             glacisRouter.glacisGMPIdToAdapter(AXELAR_GMP_ID),
             address(adapter)

--- a/test/token/mediator.t.sol
+++ b/test/token/mediator.t.sol
@@ -43,7 +43,7 @@ contract TokenMediatorTests is LocalTestSetup {
         address[] memory addrArr = new address[](1);
         addrArr[0] = addr;
 
-        glacisTokenMediator.addRemoteCounterpart(chainIdArr, addrArr);
+        glacisTokenMediator.addRemoteCounterparts(chainIdArr, addrArr);
     }
 
     function test__TokenMediator_AddsRemoteAddress(

--- a/test/token/mediator.t.sol
+++ b/test/token/mediator.t.sol
@@ -43,7 +43,7 @@ contract TokenMediatorTests is LocalTestSetup {
         address[] memory addrArr = new address[](1);
         addrArr[0] = addr;
 
-        glacisTokenMediator.addRemoteMediators(chainIdArr, addrArr);
+        glacisTokenMediator.addRemoteCounterpart(chainIdArr, addrArr);
     }
 
     function test__TokenMediator_AddsRemoteAddress(
@@ -52,7 +52,7 @@ contract TokenMediatorTests is LocalTestSetup {
     ) external {
         vm.assume(chainId != 0);
         addRemoteMediator(chainId, addr);
-        assertEq(glacisTokenMediator.remoteMediators(chainId), addr);
+        assertEq(glacisTokenMediator.remoteCounterpart(chainId), addr);
     }
 
     function test__TokenMediator_RemovesRemoteAddress(
@@ -61,8 +61,8 @@ contract TokenMediatorTests is LocalTestSetup {
     ) external {
         vm.assume(chainId != 0);
         addRemoteMediator(chainId, addr);
-        glacisTokenMediator.removeRemoteMediator(chainId);
-        assertEq(glacisTokenMediator.remoteMediators(chainId), address(0));
+        glacisTokenMediator.removeRemoteCounterpart(chainId);
+        assertEq(glacisTokenMediator.remoteCounterpart(chainId), address(0));
     }
 
     function test__TokenMediator_NonOwnersCannotAddRemote() external {
@@ -74,7 +74,7 @@ contract TokenMediatorTests is LocalTestSetup {
     function test__TokenMediator_NonOwnersCannotRemoveRemote() external {
         vm.startPrank(address(0x123));
         vm.expectRevert("Ownable: caller is not the owner");
-        glacisTokenMediator.removeRemoteMediator(block.chainid);
+        glacisTokenMediator.removeRemoteCounterpart(block.chainid);
     }
 
     function test__TokenMediator_RejectsExecuteFromNonMediatorSources(


### PR DESCRIPTION
This PR unifies the access and routing for those components that have a counterpart (mirror component) on remote chains, also allows that remote adapters can be added as an array speeding up deployment process.

The check for isChainAvailable has been removed since it is innocuous and complicates the use of the for loop. We can have a discussion if it is necessary at this point but I don't think so.