### PR TITLE
Simple Token Mediator + Token Variant to Bytes32

### DIFF
--- a/contracts/interfaces/IXERC20.sol
+++ b/contracts/interfaces/IXERC20.sol
@@ -32,7 +32,6 @@ interface IXERC20 {
     /**
      * @notice Reverts when caller is not the factory
      */
-
     error IXERC20_NotFactory();
 
     struct Bridge {
@@ -130,13 +129,18 @@ interface IXERC20 {
     function burn(address _user, uint256 _amount) external;
 }
 
+/**
+ * An optional extension to IXERC20 that the GlacisTokenMediator will query for. 
+ * It allows developers to have XERC20 tokens that have different addresses on
+ * different chains.
+ */
 interface IXERC20GlacisExtension {
     /**
      * @notice Returns a token variant for a specific chainId if it exists.
      *
      * @param chainId The chainId of the token variant.
      */
-    function getTokenVariant(uint256 chainId) external view returns (address);
+    function getTokenVariant(uint256 chainId) external view returns (bytes32);
 
     /**
      * @notice Sets a token variant for a specific chainId.
@@ -144,5 +148,5 @@ interface IXERC20GlacisExtension {
      * @param chainId The chainId of the token variant.
      * @param variant The address of the token variant.
      */
-    function setTokenVariant(uint256 chainId, address variant) external;
+    function setTokenVariant(uint256 chainId, bytes32 variant) external;
 }

--- a/contracts/mediators/SimpleTokenMediator.sol
+++ b/contracts/mediators/SimpleTokenMediator.sol
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity 0.8.18;
+
+import {IGlacisTokenClient} from "../interfaces/IGlacisTokenClient.sol";
+import {IGlacisRouter} from "../interfaces/IGlacisRouter.sol";
+import {IGlacisTokenMediator} from "../interfaces/IGlacisTokenMediator.sol";
+import {IGlacisClient} from "../interfaces/IGlacisClient.sol";
+import {IXERC20} from "../interfaces/IXERC20.sol";
+import {GlacisCommons} from "../commons/GlacisCommons.sol";
+import {GlacisRemoteCounterpartManager} from "../managers/GlacisRemoteCounterpartManager.sol";
+import {GlacisClient__CanOnlyBeCalledByRouter} from "../client/GlacisClient.sol";
+import {AddressBytes32} from "../libraries/AddressBytes32.sol";
+
+error GlacisTokenMediator__OnlyTokenMediatorAllowed();
+error GlacisTokenMediator__IncorrectTokenVariant(address, uint256);
+error GlacisTokenMediator__DestinationChainUnavailable();
+
+/** 
+ * This contract is initialized in the same way that the GlacisTokenMediator is. It allows
+ * developers to deploy their own mediator without any extra Glacis interfaces. Developers
+ * using this must ensure that their token has the same address on each chain.
+ */
+contract GlacisTokenMediator is
+    IGlacisTokenMediator,
+    GlacisRemoteCounterpartManager,
+    IGlacisClient
+{
+    using AddressBytes32 for address;
+    using AddressBytes32 for bytes32;
+
+    constructor(
+        address glacisRouter_,
+        uint256 quorum,
+        address owner
+    ) IGlacisClient(quorum) {
+        // Approve conversation between token routers in all chains through all GMPs
+        GLACIS_ROUTER = glacisRouter_;
+        transferOwnership(owner);
+    }
+
+    address public immutable GLACIS_ROUTER;
+
+    /// @notice Routes the payload to the specific address on destination chain through GlacisRouter using GMPs
+    /// specified in gmps array
+    /// @param chainId Destination chain (Glacis chain ID)
+    /// @param to Destination address on remote chain
+    /// @param payload Payload to be routed
+    /// @param gmps The GMP Ids to use for routing
+    /// @param fees Payment for each GMP to cover source and destination gas fees (excess will be refunded)
+    /// @param refundAddress Address to refund excess gas payment
+    /// @param token Token (implementing XERC20 standard) to be sent to remote contract
+    /// @param tokenAmount Amount of token to send to remote contract
+    function route(
+        uint256 chainId,
+        bytes32 to,
+        bytes memory payload,
+        uint8[] memory gmps,
+        address[] memory customAdapters,
+        uint256[] memory fees,
+        address refundAddress,
+        address token,
+        uint256 tokenAmount
+    ) public payable virtual returns (bytes32, uint256) {
+        bytes32 destinationTokenMediator = remoteCounterpart[chainId];
+        if (destinationTokenMediator == bytes32(0))
+            revert GlacisTokenMediator__DestinationChainUnavailable();
+
+        IXERC20(token).burn(msg.sender, tokenAmount);
+        bytes memory tokenPayload = packTokenPayload(
+            to,
+            token,
+            tokenAmount,
+            payload
+        );
+        emit GlacisTokenMediator__TokensBurnt(msg.sender, token, tokenAmount);
+        return
+            IGlacisRouter(GLACIS_ROUTER).route{value: msg.value}(
+                chainId,
+                destinationTokenMediator,
+                tokenPayload,
+                gmps,
+                customAdapters,
+                fees,
+                refundAddress,
+                true // Token Mediator always enables retry
+            );
+    }
+
+    /// @notice Retries routing the payload to the specific address on destination chain using specified GMPs
+    /// @param chainId Destination chain (Glacis chain ID)
+    /// @param to Destination address on remote chain
+    /// @param payload Payload to be routed
+    /// @param gmps The GMP Ids to use for routing
+    /// @param fees Payment for each GMP to cover source and destination gas fees (excess will be refunded)
+    /// @param refundAddress Address to refund excess gas payment
+    /// @param messageId The message ID of the message to retry
+    /// @param nonce The nonce emitted by the original message routing
+    /// @param token Token (implementing XERC20 standard) to be sent to remote contract
+    /// @param tokenAmount Amount of token to send to remote contract
+    function routeRetry(
+        uint256 chainId,
+        bytes32 to,
+        bytes memory payload,
+        uint8[] memory gmps,
+        address[] memory customAdapters,
+        uint256[] memory fees,
+        address refundAddress,
+        bytes32 messageId,
+        uint256 nonce,
+        address token,
+        uint256 tokenAmount
+    ) public payable virtual returns (bytes32) {
+        // Pack with a function (otherwise stack too deep)
+        bytes memory tokenPayload = packTokenPayload(
+            to,
+            token,
+            tokenAmount,
+            payload
+        );
+
+        // Use helper function (otherwise stack too deep)
+        return _routeRetry(
+            chainId,
+            tokenPayload,
+            gmps,
+            customAdapters,
+            fees,
+            refundAddress,
+            messageId,
+            nonce
+        );
+    }
+
+    function _routeRetry(
+        uint256 chainId,
+        bytes memory tokenPayload,
+        uint8[] memory gmps,
+        address[] memory customAdapters,
+        uint256[] memory fees,
+        address refundAddress,
+        bytes32 messageId,
+        uint256 nonce
+    ) private returns(bytes32) {
+        bytes32 destinationTokenMediator = remoteCounterpart[chainId];
+        if (destinationTokenMediator == bytes32(0))
+            revert GlacisTokenMediator__DestinationChainUnavailable();
+
+        return
+            IGlacisRouter(GLACIS_ROUTER).routeRetry{value: msg.value}(
+                chainId,
+                destinationTokenMediator,
+                tokenPayload,
+                gmps,
+                customAdapters,
+                fees,
+                refundAddress,
+                messageId,
+                nonce
+            );
+    }
+
+    /// @notice Receives a cross chain message from an IGlacisAdapter.
+    /// @param fromGmpIds Used GMP Ids for routing
+    /// @param fromChainId Source chain (Glacis chain ID)
+    /// @param fromChainId Source address
+    /// @param payload Received payload from Glacis Router
+    function receiveMessage(
+        uint8[] memory fromGmpIds,
+        uint256 fromChainId,
+        bytes32 fromAddress,
+        bytes memory payload
+    ) public override {
+        // Ensure that the executor is the glacis router and that the source is from an accepted mediator.
+        if (msg.sender != GLACIS_ROUTER)
+            revert GlacisClient__CanOnlyBeCalledByRouter();
+        if (fromAddress != remoteCounterpart[fromChainId]) {
+            revert GlacisTokenMediator__OnlyTokenMediatorAllowed();
+        }
+
+        (
+            bytes32 to,
+            bytes32 originalFrom,
+            address sourceToken,
+            address token,
+            uint256 tokenAmount,
+            bytes memory originalPayload
+        ) = abi.decode(
+                payload,
+                (bytes32, bytes32, address, address, uint256, bytes)
+            );
+
+        // Ensure that the destination token accepts the source token.
+        if (sourceToken != token) {
+            revert GlacisTokenMediator__IncorrectTokenVariant(
+                sourceToken,
+                fromChainId
+            );
+        }
+
+        // Mint & execute
+        address toAddress = to.toAddress();
+        IXERC20(token).mint(toAddress, tokenAmount);
+        emit GlacisTokenMediator__TokensMinted(toAddress, token, tokenAmount);
+        IGlacisTokenClient client = IGlacisTokenClient(toAddress);
+
+        if (toAddress.code.length > 0) {
+            client.receiveMessageWithTokens(
+                fromGmpIds,
+                fromChainId,
+                originalFrom,
+                originalPayload,
+                token,
+                tokenAmount
+            );
+        }
+    }
+
+    /// @notice The quorum of messages that the contract expects with a specific message from the
+    ///         token router
+    /// @param glacisData The glacis config data that comes with the message
+    /// @param payload The payload that comes with the message
+    function getQuorum(
+        GlacisCommons.GlacisData memory glacisData,
+        bytes memory payload
+    ) public view override returns (uint256) {
+        (
+            bytes32 to,
+            bytes32 originalFrom,
+            address token,
+            uint256 tokenAmount,
+            bytes memory originalPayload
+        ) = decodeTokenPayload(payload);
+        glacisData.originalFrom = originalFrom;
+        glacisData.originalTo = to;
+
+        // If the destination smart contract is an EOA, then we assume "1".
+        address toAddress = to.toAddress();
+        if (toAddress.code.length == 0) {
+            return 1;
+        }
+
+        return
+            IGlacisTokenClient(toAddress).getQuorum(
+                glacisData,
+                originalPayload,
+                token,
+                tokenAmount
+            );
+    }
+
+    /// @notice Queries if a route from path GMP+Chain+Address is allowed for this client
+    /// @param fromChainId Source chain Id
+    /// @param fromAddress Source address
+    /// @param fromGmpId source GMP Id
+    /// @return True if route is allowed, false otherwise
+    function isAllowedRoute(
+        uint256 fromChainId,
+        bytes32 fromAddress,
+        uint160 fromGmpId,
+        bytes memory payload
+    ) external view returns (bool) {
+        // First checks to ensure that the GlacisTokenMediator is speaking to a registered remote version
+        if (fromAddress != remoteCounterpart[fromChainId]) return false;
+
+        (
+            bytes32 to,
+            bytes32 originalFrom,
+            ,
+            ,
+            bytes memory originalPayload
+        ) = decodeTokenPayload(payload);
+
+        // If the destination smart contract is an EOA, then we allow it.
+        address toAddress = to.toAddress();
+        if (toAddress.code.length == 0) {
+            return true;
+        }
+
+        // Forwards check to the token client
+        return
+            IGlacisTokenClient(toAddress).isAllowedRoute(
+                fromChainId,
+                originalFrom,
+                fromGmpId,
+                originalPayload
+            );
+    }
+
+    function isCustomAdapter(
+        address adapter,
+        GlacisCommons.GlacisData memory glacisData,
+        bytes memory payload
+    ) public override returns (bool) {
+        (
+            bytes32 to,
+            ,
+            address token,
+            uint256 tokenAmount,
+
+        ) = decodeTokenPayload(payload);
+
+        // If the destination smart contract is an EOA, then it is not.
+        address toAddress = to.toAddress();
+        if (toAddress.code.length == 0) {
+            return false;
+        }
+
+        // Forwards check to the token client
+        return
+            IGlacisTokenClient(toAddress).isCustomAdapter(
+                adapter,
+                glacisData,
+                payload,
+                token,
+                tokenAmount
+            );
+    }
+
+    function packTokenPayload(
+        bytes32 to,
+        address token,
+        uint256 tokenAmount,
+        bytes memory payload
+    ) internal view returns (bytes memory) {
+        return
+            abi.encode(
+                to,
+                msg.sender.toBytes32(),
+                token,
+                tokenAmount,
+                payload
+            );
+    }
+
+    function decodeTokenPayload(
+        bytes memory payload
+    )
+        internal
+        pure
+        returns (
+            bytes32 to,
+            bytes32 originalFrom,
+            address sourceToken,
+            uint256 tokenAmount,
+            bytes memory originalPayload
+        )
+    {
+        (
+            to,
+            originalFrom,
+            sourceToken,
+            tokenAmount,
+            originalPayload
+        ) = abi.decode(
+            payload,
+            (bytes32, bytes32, address, uint256, bytes)
+        );
+    }
+}

--- a/contracts/mediators/SimpleTokenMediator.sol
+++ b/contracts/mediators/SimpleTokenMediator.sol
@@ -16,11 +16,9 @@ error GlacisTokenMediator__OnlyTokenMediatorAllowed();
 error GlacisTokenMediator__IncorrectTokenVariant(address, uint256);
 error GlacisTokenMediator__DestinationChainUnavailable();
 
-/** 
- * This contract is initialized in the same way that the GlacisTokenMediator is. It allows
- * developers to deploy their own mediator without any extra Glacis interfaces. Developers
- * using this must ensure that their token has the same address on each chain.
- */
+/// This contract is initialized in the same way that the GlacisTokenMediator is. It allows
+/// developers to deploy their own mediator without any extra Glacis interfaces. Developers
+/// using this must ensure that their token has the same address on each chain.
 contract GlacisTokenMediator is
     IGlacisTokenMediator,
     GlacisRemoteCounterpartManager,

--- a/contracts/token/XERC20.sol
+++ b/contracts/token/XERC20.sol
@@ -5,6 +5,7 @@ import {IXERC20, IXERC20GlacisExtension} from "../interfaces/IXERC20.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {AddressBytes32} from "../libraries/AddressBytes32.sol";
 
 error XERC20__OnlyBridge();
 
@@ -344,7 +345,7 @@ contract XERC20 is XERC20Basic, IXERC20GlacisExtension {
         address _factory
     ) XERC20Basic(_name, _symbol, _factory) {}
 
-    mapping(uint256 => address) private chainIdToTokenVariant;
+    mapping(uint256 => bytes32) private chainIdToTokenVariant;
 
     /**
      * @notice Returns a token variant for a specific chainId if it exists.
@@ -353,7 +354,7 @@ contract XERC20 is XERC20Basic, IXERC20GlacisExtension {
      */
     function getTokenVariant(
         uint256 chainId
-    ) external view override returns (address) {
+    ) external view override returns (bytes32) {
         return chainIdToTokenVariant[chainId];
     }
 
@@ -365,7 +366,7 @@ contract XERC20 is XERC20Basic, IXERC20GlacisExtension {
      */
     function setTokenVariant(
         uint256 chainId,
-        address variant
+        bytes32 variant
     ) external onlyOwner {
         chainIdToTokenVariant[chainId] = variant;
     }


### PR DESCRIPTION
- Adds a simple token mediator that does not include the Glacis XERC20 extension (for Moonwell)
- Converts the token variant in Glacis XERC20 extension to bytes32 so that XERC20 could potentially work for non-EVM chains
- Adds 2 forge tests for token variants