### PR TITLE
Dockerize project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,5 @@ RUN mkdir foundry &&\
     curl -L https://foundry.paradigm.xyz | bash &&\
     . ~/.bashrc &&\
     foundryup
+RUN apt-get update && apt-get install -y apt-transport-https
+RUN apt-get install -y lcov

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "glacisv1",
   "scripts": {
     "test": "forge test",
+    "coverage": "forge coverage --report lcov; genhtml --branch-coverage lcov.info -output lcov.html",
     "test:forge:debug": "forge test -vvv",
     "test:gas": "bash scripts/plotGas.sh",
     "hint": "solhint 'contracts/**/*.sol' 'test/**/*.sol'",


### PR DESCRIPTION
In VS code run command:  "Dev Containers: Reopen in Container" this should allow to run the coverage tool.
(The tests run a little bit slowly)